### PR TITLE
New 'nxlog.runas' property

### DIFF
--- a/jobs/nxlog/spec
+++ b/jobs/nxlog/spec
@@ -31,3 +31,6 @@ properties:
       - {path: "/var/log/test.log", recursive: false, exclude: ""}
     default:
       - {path: "/var/vcap/data/sys/log/*.log", recursive: true, exclude: "(monit|nxlog)"}
+  nxlog.runas:
+    description: "An optional user:group[:group] string for specifying what user and group(s) to run nxlog as"
+    default:     "vcap:vcap:adm:admin"

--- a/jobs/nxlog/templates/bin/nxlog_ctl
+++ b/jobs/nxlog/templates/bin/nxlog_ctl
@@ -19,7 +19,7 @@ case $1 in
       mv -f /etc/cron.daily/logrotate /etc/cron.hourly/
     fi
 
-    exec chpst -u vcap:vcap:adm:admin /var/vcap/packages/nxlog/bin/nxlog \
+    exec chpst -u <%= p('nxlog.runas') %> /var/vcap/packages/nxlog/bin/nxlog \
       -c $JOB_DIR/config/nxlog.conf \
       1>>$LOG_DIR/$JOB_NAME.stdout.log \
       2>>$LOG_DIR/$JOB_NAME.stderr.log


### PR DESCRIPTION
This optional property allows deployment configurations where nxlog
needs to run as a user other than the default vcap:vcap, (i.e.
root:root).
